### PR TITLE
Made camera GUI icon look isometric

### DIFF
--- a/src/main/resources/assets/polaroidcamera/models/item/camera.json
+++ b/src/main/resources/assets/polaroidcamera/models/item/camera.json
@@ -125,8 +125,8 @@
 			"scale": [0.69, 0.69, 0.69]
 		},
 		"gui": {
-			"rotation": [0, -180, 0],
-			"translation": [0, 3.5, 0]
+			"rotation": [22, -145, 0],
+			"translation": [0.25, 3.5, 0]
 		},
 		"fixed": {
 			"translation": [0, 4.5, 0]


### PR DESCRIPTION
This is a super simple data edit to make the camera look nicer in the GUI!
(Feel free to tweak the angle.)

## Before:
![image](https://github.com/HyperPigeon/PolaroidCamera/assets/56928485/b9345009-4b1c-4bd8-9263-5f0585970305)

## After:
![image](https://github.com/HyperPigeon/PolaroidCamera/assets/56928485/29ff0b04-b526-404a-9b27-0e7579074b88)

![image](https://github.com/HyperPigeon/PolaroidCamera/assets/56928485/6ee4d7e0-70a0-480a-9ac0-d642d6e0e87a)
